### PR TITLE
Enable editing tasks via double click

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,10 +45,8 @@ function renderTasks() {
             renderTasks();
         });
 
-        // Botón para editar la tarea
-        const editBtn = document.createElement('button');
-        editBtn.textContent = 'Editar';
-        editBtn.addEventListener('click', () => {
+        // Permitir edición con doble clic
+        textSpan.addEventListener('dblclick', () => {
             const newText = prompt('Editar tarea:', task.text);
             if (newText !== null && newText.trim() !== '') {
                 tasks[index].text = newText.trim();
@@ -67,7 +65,6 @@ function renderTasks() {
         });
 
         li.appendChild(completeBtn);
-        li.appendChild(editBtn);
         li.appendChild(deleteBtn);
         taskList.appendChild(li);
     });


### PR DESCRIPTION
## Summary
- remove Edit button
- let user edit tasks by double clicking the task text

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6841c55664608328818367eed307cb6d