### PR TITLE
Add checkbox-based task grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# ejercicio1
+# Ejercicio 1
+
+Gestor de tareas sencillo donde puedes agregar tareas y marcarlas como
+completadas. Las tareas se muestran separadas en dos listas: **Pendientes** y
+**Completadas**. Cada tarea cuenta con un cuadro de selección para indicar su
+estado, además de opciones para editarla o eliminarla.

--- a/app.js
+++ b/app.js
@@ -1,7 +1,8 @@
 // Referencias a elementos del DOM
 const taskInput = document.getElementById('task-input');
 const addTaskButton = document.getElementById('add-task');
-const taskList = document.getElementById('task-list');
+const pendingList = document.getElementById('pending-list');
+const completedList = document.getElementById('completed-list');
 const progressDisplay = document.getElementById('progress');
 
 // Cargar tareas guardadas al iniciar la página
@@ -26,24 +27,29 @@ function updateStorage() {
 }
 
 function renderTasks() {
-    taskList.innerHTML = '';
+    pendingList.innerHTML = '';
+    completedList.innerHTML = '';
+
     tasks.forEach((task, index) => {
         const li = document.createElement('li');
-        const textSpan = document.createElement('span');
-        textSpan.textContent = task.text;
-        li.appendChild(textSpan);
-        if (task.completed) {
-            li.classList.add('completed');
-        }
 
-        // Botón para marcar como completada
-        const completeBtn = document.createElement('button');
-        completeBtn.textContent = 'Completar';
-        completeBtn.addEventListener('click', () => {
-            tasks[index].completed = !tasks[index].completed;
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = task.completed;
+        checkbox.addEventListener('change', () => {
+            tasks[index].completed = checkbox.checked;
             updateStorage();
             renderTasks();
         });
+        li.appendChild(checkbox);
+
+        const textSpan = document.createElement('span');
+        textSpan.textContent = task.text;
+        li.appendChild(textSpan);
+
+        if (task.completed) {
+            li.classList.add('completed');
+        }
 
         // Botón para editar la tarea
         const editBtn = document.createElement('button');
@@ -66,10 +72,14 @@ function renderTasks() {
             renderTasks();
         });
 
-        li.appendChild(completeBtn);
         li.appendChild(editBtn);
         li.appendChild(deleteBtn);
-        taskList.appendChild(li);
+
+        if (task.completed) {
+            completedList.appendChild(li);
+        } else {
+            pendingList.appendChild(li);
+        }
     });
 
     const completed = tasks.filter(task => task.completed).length;

--- a/index.html
+++ b/index.html
@@ -16,8 +16,14 @@
         <input id="task-input" type="text" placeholder="Nueva tarea">
         <button id="add-task">Agregar</button>
 
-        <!-- Lista donde se mostrarán las tareas -->
-        <ul id="task-list"></ul>
+        <h2>Pendientes</h2>
+        <!-- Lista de tareas pendientes -->
+        <ul id="pending-list" class="task-list"></ul>
+
+        <h2>Completadas</h2>
+        <!-- Lista de tareas completadas -->
+        <ul id="completed-list" class="task-list"></ul>
+
         <div id="progress"></div>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -42,13 +42,14 @@ button:hover {
     background-color: #0056b3;
 }
 
-#task-list {
+/* Listados de tareas */
+.task-list {
     list-style: none;
     padding: 0;
     margin-top: 1rem;
 }
 
-#task-list li {
+.task-list li {
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
## Summary
- separate tasks into pending and completed lists
- style new lists
- add checkbox to mark tasks done and move them between lists
- update README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c650623c83289d95ce8920b7e444