### PR TITLE
Implement inline editing and multiple lists

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 // Referencias a elementos del DOM
 const taskInput = document.getElementById('task-input');
 const addTaskButton = document.getElementById('add-task');
+const tasksList = document.getElementById('tasks-list');
 const pendingList = document.getElementById('pending-list');
 const completedList = document.getElementById('completed-list');
 const progressDisplay = document.getElementById('progress');
@@ -27,65 +28,80 @@ function updateStorage() {
 }
 
 function renderTasks() {
+    tasksList.innerHTML = '';
     pendingList.innerHTML = '';
     completedList.innerHTML = '';
 
     tasks.forEach((task, index) => {
-        const li = document.createElement('li');
+        const createItem = () => {
+            const li = document.createElement('li');
 
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.checked = task.completed;
-        checkbox.addEventListener('change', () => {
-            tasks[index].completed = checkbox.checked;
-            updateStorage();
-            renderTasks();
-        });
-        li.appendChild(checkbox);
-
-        const textSpan = document.createElement('span');
-        textSpan.textContent = task.text;
-        li.appendChild(textSpan);
-
-        if (task.completed) {
-            li.classList.add('completed');
-        }
-
-        // Botón para marcar como completada
-        const completeBtn = document.createElement('button');
-        completeBtn.textContent = 'Completar';
-        completeBtn.addEventListener('click', () => {
-            tasks[index].completed = !tasks[index].completed;
-            updateStorage();
-            renderTasks();
-        });
-
-        // Permitir edición con doble clic
-        textSpan.addEventListener('dblclick', () => {
-            const newText = prompt('Editar tarea:', task.text);
-            if (newText !== null && newText.trim() !== '') {
-                tasks[index].text = newText.trim();
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = task.completed;
+            checkbox.addEventListener('change', () => {
+                tasks[index].completed = checkbox.checked;
                 updateStorage();
                 renderTasks();
+            });
+            li.appendChild(checkbox);
+
+            const textSpan = document.createElement('span');
+            textSpan.textContent = task.text;
+            li.appendChild(textSpan);
+
+            if (task.completed) {
+                li.classList.add('completed');
             }
-        });
 
-        // Botón para eliminar la tarea
-        const deleteBtn = document.createElement('button');
-        deleteBtn.textContent = '🗑️';
-        deleteBtn.addEventListener('click', () => {
-            tasks.splice(index, 1);
-            updateStorage();
-            renderTasks();
-        });
+            // Permitir edición con doble clic en la misma página
+            textSpan.addEventListener('dblclick', () => {
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.value = task.text;
+                li.replaceChild(input, textSpan);
+                input.focus();
 
-        li.appendChild(completeBtn);
-        li.appendChild(deleteBtn);
+                const save = () => {
+                    const newText = input.value.trim();
+                    if (newText !== '') {
+                        tasks[index].text = newText;
+                    }
+                    updateStorage();
+                    renderTasks();
+                };
 
+                input.addEventListener('blur', save);
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        save();
+                    } else if (e.key === 'Escape') {
+                        renderTasks();
+                    }
+                });
+            });
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.textContent = '🗑️';
+            deleteBtn.addEventListener('click', () => {
+                tasks.splice(index, 1);
+                updateStorage();
+                renderTasks();
+            });
+            li.appendChild(deleteBtn);
+
+            return li;
+        };
+
+        // Elemento para la lista de todas las tareas
+        tasksList.appendChild(createItem());
+
+        // Elemento para listas según estado
+        const statusItem = createItem();
         if (task.completed) {
-            completedList.appendChild(li);
+            completedList.appendChild(statusItem);
         } else {
-            pendingList.appendChild(li);
+            pendingList.appendChild(statusItem);
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,14 @@
         <input id="task-input" type="text" placeholder="Nueva tarea">
         <button id="add-task">Agregar</button>
 
-        <!-- Listas para tareas pendientes y completadas -->
+        <!-- Listas de tareas -->
+        <h2>Todas las tareas</h2>
+        <ul id="tasks-list"></ul>
+
+        <h2>Pendientes</h2>
         <ul id="pending-list"></ul>
+
+        <h2>Completadas</h2>
         <ul id="completed-list"></ul>
         <div id="progress"></div>
     </main>

--- a/style.css
+++ b/style.css
@@ -42,6 +42,7 @@ button:hover {
     background-color: #0056b3;
 }
 
+#tasks-list,
 #pending-list,
 #completed-list {
     list-style: none;
@@ -49,6 +50,7 @@ button:hover {
     margin-top: 1rem;
 }
 
+#tasks-list li,
 #pending-list li,
 #completed-list li {
     display: flex;


### PR DESCRIPTION
## Summary
- support inline editing instead of prompt dialog
- add `tasks-list` with matching styles
- update rendering logic to populate lists of all tasks, pending tasks and completed tasks
- remove the `Completar` button since completion is managed via checkboxes

## Testing
- `npx eslint .` *(fails: no such config)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf392094832885d87ee677644079